### PR TITLE
Fixed mobs not dropping items on death

### DIFF
--- a/src/main/me/ryanhamshire/ExtraHardMode/features/Antigrinder.java
+++ b/src/main/me/ryanhamshire/ExtraHardMode/features/Antigrinder.java
@@ -61,7 +61,7 @@ public class Antigrinder implements Listener
         if (inhibitMonsterGrindersEnabled)
         {
             // spawners and spawn eggs always spawn a monster, but the monster doesn't drop any loot
-            if (reason == CreatureSpawnEvent.SpawnReason.SPAWNER && blazeBonusSpawnPercent > 0 || !(entity instanceof Blaze))
+            if (reason == CreatureSpawnEvent.SpawnReason.SPAWNER && !((entity instanceof Blaze)) && blazeBonusSpawnPercent <= 0)
             {
                 entityModule.markLootLess(entity);
             }


### PR DESCRIPTION
"if (reason == CreatureSpawnEvent.SpawnReason.SPAWNER && blazeBonusSpawnPercent > 0 || !(entity instanceof Blaze))"

This is the replaced code; I believe the problem lies in nesting -- it looks like what was intended was to make Blazes not be subject to the noLoot flag unless blazeBonusSpawnPercent is greater than 0 (this is how I wrote the replacement code).  But, as written, consider the natural spawning of a Skeleton;

reason evaluates to false;
blazeBonus is irrelevant, as will become clear;
and entity evaluates to false;
our statement becomes "if (false && ???? || !(false))."

Since there's no nesting, the statement is evaluated left-to-right; "false && ????" becomes "false", and "!(false)" is simply another way of saying "(true)", so the final statement is "if (false || true)", and the markLootLess code executes -- on a mob that spawned naturally!
