### PR TITLE
Ensure bonusNetherBlazeSpawnPercent applies only to Blazes in Nether

### DIFF
--- a/src/main/me/ryanhamshire/ExtraHardMode/features/monsters/Blazes.java
+++ b/src/main/me/ryanhamshire/ExtraHardMode/features/monsters/Blazes.java
@@ -60,7 +60,7 @@ public class Blazes implements Listener
         // FEATURE: more blazes in nether
         if (entityType == EntityType.PIG_ZOMBIE)
         {
-            if (plugin.random(bonusNetherBlazeSpawnPercent))
+            if (plugin.random(bonusNetherBlazeSpawnPercent) && world.getEnvironment() == World.Environment.NETHER)
             {
                 event.setCancelled(true);
                 entityType = EntityType.BLAZE;


### PR DESCRIPTION
I have a plugin that is spawning PigZombies in the overworld, and this bit of code was changing them to blazes; I've made the code check for the world the entity is spawning in before processing the change.

Also, thanks for writing such well-organized and easy-to-troubleshoot code.  I hope you haven't been feeling a bunch of grief by my constant nagging; rather, I really enjoy this plugin and have been using it in conjunction with a couple others to make a very difficult server I am thoroughly enjoying.  If I ever get it ready for public viewing, I'll be sure to clue you in on it!  Much obliged for all your hard work!
