### PR TITLE
Refactored Break Torch to use a list of blocks to break

### DIFF
--- a/src/main/java/com/extrahardmode/config/RootConfig.java
+++ b/src/main/java/com/extrahardmode/config/RootConfig.java
@@ -330,6 +330,7 @@ public class RootConfig extends MultiWorldConfig
                     break;
                 }
                 case MORE_FALLING_BLOCKS:
+                case BREAKABLE_BY_FALLING_BLOCKS:
                 case SUPER_HARD_STONE_TOOLS:
                 case SUPER_HARD_STONE_PHYSICS_BLOCKS:
                 {
@@ -389,7 +390,8 @@ public class RootConfig extends MultiWorldConfig
         {
             switch (node)
             {
-                case MORE_FALLING_BLOCKS:
+            	case MORE_FALLING_BLOCKS:
+            	case BREAKABLE_BY_FALLING_BLOCKS:
                 {
                     reorderedConfig.set(node.getPath(),
                             SpecialParsers.convertToStringList(

--- a/src/main/java/com/extrahardmode/config/RootNode.java
+++ b/src/main/java/com/extrahardmode/config/RootNode.java
@@ -566,7 +566,7 @@ public enum RootNode implements ConfigNode
     /**
      * Should Falling Blocks break torches when they land
      */
-    MORE_FALLING_BLOCKS_BREAK_TORCHES("Additional Falling Blocks.Break Torches", VarType.BOOLEAN, true),
+    MORE_FALLING_BLOCKS_BREAK_BLOCKS("Additional Falling Blocks.Break Blocks", VarType.BOOLEAN, true),
     /**
      * Cascading falling blocks
      */
@@ -583,6 +583,10 @@ public enum RootNode implements ConfigNode
      * which materials beyond sand and gravel should be subject to gravity
      */
     MORE_FALLING_BLOCKS("Additional Falling Blocks.Enabled Blocks", VarType.LIST, new DefaultFallingBlocks()),
+    /**
+     * which materials should Falling Blocks break
+     */
+    BREAKABLE_BY_FALLING_BLOCKS("Additional Falling Blocks.Breakable Blocks", VarType.LIST, new DefaultBreakableByFallingBlocks()),
 
     /**
      * ##############################
@@ -1056,6 +1060,31 @@ public enum RootNode implements ConfigNode
             this.add(Material.STEP.toString() + "@3");
             this.add(Material.STEP.toString() + "@11");
             this.add(Material.MYCEL.toString());
+        }
+    }
+
+
+    /**
+     * Default list of blocks breakable by falling blocks.
+     */
+    private static class DefaultBreakableByFallingBlocks extends ArrayList<String>
+    {
+
+        /**
+         * Serial Version UID.
+         */
+        private static final long serialVersionUID = 1L;
+
+
+        /**
+         * Constructor.
+         */
+        public DefaultBreakableByFallingBlocks()
+        {
+            super();
+            this.add(Material.SAPLING.toString());
+            this.add(Material.TORCH.toString());
+            this.add(Material.FIRE.toString());
         }
     }
 

--- a/src/main/java/com/extrahardmode/module/BlockModule.java
+++ b/src/main/java/com/extrahardmode/module/BlockModule.java
@@ -118,9 +118,9 @@ public class BlockModule extends EHMModule
         CompatHandler.logFallingBlockFall(block);
         block.setType(Material.AIR);
 
-        final boolean breakTorches = CFG.getBoolean(RootNode.MORE_FALLING_BLOCKS_BREAK_TORCHES, block.getWorld().getName());
+        final boolean breakBlocks = CFG.getBoolean(RootNode.MORE_FALLING_BLOCKS_BREAK_BLOCKS, block.getWorld().getName());
         //TODO expand on this, it's only rudimentary, doesnt break torches if there are multiple fallingblocks (only breaks the first)
-        if (breakTorches)
+        if (breakBlocks)
         {
             Block current = block;
             Block below = block.getRelative(BlockFace.DOWN);

--- a/src/main/java/com/extrahardmode/task/BlockPhysicsCheckTask.java
+++ b/src/main/java/com/extrahardmode/task/BlockPhysicsCheckTask.java
@@ -92,11 +92,14 @@ public class BlockPhysicsCheckTask implements Runnable
 
         final boolean fallingBlocksEnabled = CFG.getBoolean(RootNode.MORE_FALLING_BLOCKS_ENABLE, block.getWorld().getName());
         final Map<Integer, List<Byte>> fallingBlocks = CFG.getMappedNode(RootNode.MORE_FALLING_BLOCKS, block.getWorld().getName());
+        final Map<Integer, List<Byte>> breakableByFallingBlocks = CFG.getMappedNode(RootNode.BREAKABLE_BY_FALLING_BLOCKS, block.getWorld().getName());
 
         Material material = block.getType();
         Block underBlock = block.getRelative(BlockFace.DOWN);
 
-        if ((underBlock.getType() == Material.AIR || underBlock.isLiquid() || underBlock.getType() == Material.TORCH)
+        if ((underBlock.getType() == Material.AIR || underBlock.isLiquid() ||
+                /* Blocks that get broken by falling blocks */
+                (breakableByFallingBlocks.containsKey(underBlock.getTypeId()) && (breakableByFallingBlocks.get(underBlock.getTypeId()).isEmpty() || breakableByFallingBlocks.get(underBlock.getTypeId()).contains(block.getData()))))
                 && (material == Material.SAND || material == Material.GRAVEL ||
                 /* Our extra blocks */
                 (fallingBlocks.containsKey(material.getId()) && (fallingBlocks.get(material.getId()).isEmpty() || fallingBlocks.get(material.getId()).contains(block.getData()))))


### PR DESCRIPTION
Allows the user to specify what blocks should be broken if below a falling block. This allows for more customization like breaking grass,redstone torches buttons and others.

Default broken blocks are FIRE, TORCH and SAPLING

NOTE: I'm not familiar with your config loading code so I didn't add a check for cases where falling blocks are also on the breakable blocks list! If you could add this check it would be great. Things can get messy if they are on the same list! Ex: dirt causing dirt to break and fall.
Sorry for not adding the check, I'm not all that great with coding yet! 
