### PR TITLE
add damage multipliers for starvation and drowning

### DIFF
--- a/src/main/java/com/extrahardmode/config/RootNode.java
+++ b/src/main/java/com/extrahardmode/config/RootNode.java
@@ -226,6 +226,10 @@ public enum RootNode implements ConfigNode
 
     ENHANCED_DMG_BURN("Player.Enhanced Environmental Injuries.Burning", VarType.POTION_EFFECT, new PotionEffectHolder(PotionEffectType.BLINDNESS, 20, 1)),
 
+    ENHANCED_DMG_STARVATION_MULT("Player.Enhanced Environmental Injuries.Starvation.Dmg Multiplier", VarType.DOUBLE, 2.0),
+
+    ENHANCED_DMG_DROWNING_MULT("Player.Enhanced Environmental Injuries.Drowning.Dmg Multiplier", VarType.DOUBLE, 2.0),
+
     /**
      * whether players catch fire when extinguishing a fire up close
      */

--- a/src/main/java/com/extrahardmode/features/Players.java
+++ b/src/main/java/com/extrahardmode/features/Players.java
@@ -231,6 +231,28 @@ public class Players extends ListenerModule
                         applyEffectOnDmg(event, CFG.getPotionEffect(RootNode.ENHANCED_DMG_BURN, world.getName()), CFG.getDouble(RootNode.ENHANCED_DMG_BURN_MULT, world.getName()));
 //                        player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 20, 1));
                         break;
+                    case DROWNING:
+                        applyEffectOnDmg(event, null, CFG.getDouble(RootNode.ENHANCED_DMG_DROWNING_MULT, world.getName()));
+                        break;
+                    case STARVATION:
+                        applyEffectOnDmg(event, null, CFG.getDouble(RootNode.ENHANCED_DMG_STARVATION_MULT, world.getName()));
+                        break;
+
+                    case CONTACT:
+                    case CUSTOM:
+                    case ENTITY_ATTACK:
+                    case FALLING_BLOCK:
+                    case FIRE:
+                    case LIGHTNING:
+                    case MAGIC:
+                    case MELTING:
+                    case POISON:
+                    case PROJECTILE:
+                    case SUICIDE:
+                    case THORNS:
+                    case VOID:
+                    case WITHER:
+                        break;
                 }
             }
         }
@@ -242,7 +264,9 @@ public class Players extends ListenerModule
     private void applyEffectOnDmg(EntityDamageEvent event, PotionEffectHolder potionEffect, double multiplier)
     {
         //Assume it's a LivingEntity,
-        potionEffect.applyEffect((LivingEntity) event.getEntity(), false);
+        if (potionEffect != null) {
+            potionEffect.applyEffect((LivingEntity) event.getEntity(), false);
+        }
         event.setDamage((int) (event.getDamage() * multiplier));
     }
 


### PR DESCRIPTION
adding damage multipliers for starvation and drowning damage. defaulting to 2.0 like most others.

tested setting them to 2000 for an insta-kill, per http://forums.bukkit.org/threads/increased-survival-difficulty.284902/.

will research zombie torch breaking for another PR.
